### PR TITLE
Simplify docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8u171-jre-alpine3.8
 
-
-
 ARG guest_java_opts
 ARG spring_profiles=default,production
 ARG environment=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,14 @@
 FROM openjdk:8u171-jre-alpine3.8
 
-ARG guest_java_opts
-ARG spring_profiles=default,production
-ARG environment=production
-ARG newrelic_enabled=false
-ARG jar_file
+ARG JAR_FILE
 
-COPY ${jar_file} app.jar
+COPY ${JAR_FILE} app.jar
 COPY newrelic-agent-*.jar newrelic/newrelic.jar
 COPY newrelic.yml newrelic/newrelic.yml
 
 EXPOSE 8080
 
-ENV JAVA_OPTS "${guest_java_opts} -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -javaagent:newrelic/newrelic.jar -Dnewrelic.config.agent_enabled=${newrelic_enabled} -Dnewrelic.environment=${environment} -Dnewrelic.config.file=/newrelic.yml -Djava.security.egd=file:/dev/./urandom -Dspring.profiles.active=${spring_profiles}"
-
-ENTRYPOINT exec java ${JAVA_OPTS} -jar app.jar
+ENTRYPOINT exec java $JAVA_OPTS -jar app.jar
 
 HEALTHCHECK --start-period=90s \
   CMD wget --quiet --tries=1 --spider --timeout=30 http://localhost:8080/actuator/health || exit 1

--- a/README.md
+++ b/README.md
@@ -24,29 +24,30 @@ For IDEs run one of the following commands before importing into your IDE.
 ```
 
 ### How to: Build and run locally on Docker
-1. `./gradlew clean assemble check docker -PREPOSITORY_URI=spring-boot-java-base`
-2. `docker run -p 8080:8080 -i -t "spring-boot-java-base"`
+1. `./gradlew clean assemble check docker`
+2. `docker run -e SPRING_PROFILES_ACTIVE=localhost -p 8080:8080 -i -t spring-boot-java-base`
 
 #### Debug / Profiling
-To debug the container locally, add the following line in to the ENTRYPOINT line after `java` and before `-jar`.
+To debug the container locally, the `JAVA_OPTS` environment variable can be provided when running the container.
 ```bash
-"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+docker run -p 8080:8080 -i -t -e JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005" spring-boot-java-base
 ```
-Once this has been added build and run the docker container locally.
+
+### Enabling New Relic
+New relic can be enabled by providing the following `JAVA_OPTS` environment variable. Ensure to provide the correct `newrelic.environment` system property. To configure New Relic add/update the Application Environments section in `newrelic.yml`, more information can be found [here](https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file). 
+```base
+docker run -p 8080:8080 -i -t -e JAVA_OPTS="-javaagent:newrelic/newrelic.jar -Dnewrelic.environment=${environment} -Dnewrelic.config.file=newrelic/newrelic.yml" spring-boot-java-base
+```
 
 ### How to: Build production equivalent container
 ```bash
-./gradlew clean assemble check docker dockerTag -PTAG=$(git rev-parse --verify HEAD --short) -PBRANCH=$(git rev-parse --abbrev-ref HEAD) \
-  -PREPOSITORY_URI=${DOCKER_REPO}${IMAGE_NAME}
+./gradlew clean assemble check docker dockerTag -PTAG=$(git rev-parse --verify HEAD --short) -PREPOSITORY_URI=${DOCKER_REPO}${IMAGE_NAME}
 ```
 
-### How to: Override application context
-The docker build stage in Gradle accepts a parameter called APPLICATION_CONTEXT, which is passed to Spring boot and used in the Docker container
-Healthcheck.
-
-```bash
-./gradlew clean assemble check docker \
-  -PAPPLICATION_CONTEXT="your-app-context"
+#### Recommended JAVA_OPTS
+It is strongly recommended that the following Java Options are set when running the service in production.
+```base
+JAVA_OPTS="-XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -javaagent:newrelic/newrelic.jar -Dnewrelic.environment=${environment} -Dnewrelic.config.file=/newrelic.yml -Djava.security.egd=file:/dev/./urandom"
 ```
 
 ## For more tasks run

--- a/build.gradle
+++ b/build.gradle
@@ -82,33 +82,10 @@ if (!project.hasProperty("TAG")) {
 }
 
 docker {
-    name project.hasProperty("REPOSITORY_URI") ? "${REPOSITORY_URI}" : "sbjb"
+    name project.hasProperty("REPOSITORY_URI") ? "${REPOSITORY_URI}" : "${project.name}"
     tags "${TAG}", 'latest'
-    files jar.archivePath, "${project.projectDir.absolutePath}/lib/newrelic-agent-4.1.0.jar", "${project.projectDir.absolutePath}/config/newrelic/newrelic.yml"
-    def argMap = [
-        'jar_file'           : "${bootJar.archiveName}",
-        'newrelic_enabled' : "true"
-    ]
-
-    // These are optional args.
-    if (project.hasProperty("SPRING_PROFILES")) {
-        argMap.spring_profiles = "${SPRING_PROFILES}"
-    }
-    if (project.hasProperty("GUEST_JAVA_OPTS")) {
-        argMap.guest_java_opts = "${GUEST_JAVA_OPTS}"
-    }
-    if (project.hasProperty("ENVIRONMENT")) {
-        argMap.environment = "${ENVIRONMENT}"
-    }
-    if (project.hasProperty("NEWRELIC_ENABLED")) {
-        argMap.newrelic_enabled = "${NEWRELIC_ENABLED}"
-    }
-    buildArgs(argMap)
-
-    printf("docker name is [${name}]\n")
-    printf("docker archive path is [${jar.archivePath}]\n")
-    printf("docker archive name is [${bootJar.archiveName}]\n")
-    printf("docker app jar is [${argMap.jar_file}]\n")
+    files bootJar.archivePath, "${project.projectDir.absolutePath}/lib/newrelic-agent-4.1.0.jar", "${project.projectDir.absolutePath}/config/newrelic/newrelic.yml"
+    buildArgs(['JAR_FILE': "${bootJar.archiveName}"])
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.spotbugs" version "1.6.1"
+    id "com.github.spotbugs" version "1.6.2"
     id "org.springframework.boot" version "2.0.3.RELEASE"
     id "io.spring.dependency-management" version "1.0.5.RELEASE"
     id "com.palantir.docker" version "0.20.1"

--- a/config/newrelic/newrelic.yml
+++ b/config/newrelic/newrelic.yml
@@ -29,7 +29,7 @@ common: &default_settings
   # app_name: My Application;My Application 2
   # This setting is required. Up to 3 different application names can be specified.
   # The first application name must be unique.
-  app_name: Spring boot java app name
+  app_name: Spring Boot Java Base
 
   # To enable high security, set this property to true. When in high
   # security mode, the agent will use SSL and obfuscated SQL. Additionally,
@@ -258,7 +258,6 @@ common: &default_settings
   # There is a maximum of 64 labels per agent.  Names and values are limited to 255 characters.
   # Names and values may not contain colons (:) or semicolons (;).
   labels:
-
     # An example label
     #label_name: label_value
 
@@ -274,10 +273,19 @@ common: &default_settings
 
 # NOTE if your application has other named environments, you should
 # provide configuration settings for these environments here.
+localhost:
+  <<: *default_settings
+  app_name: Spring Boot Java Base (localhost)
+  agent_enabled: false
+  license_key:
 
 development:
   <<: *default_settings
-  app_name: Spring boot java app name (Development)
+  app_name: Spring Boot Java Base (development)
+  agent_enabled: true
+  license_key:
 
 production:
   <<: *default_settings
+  agent_enabled: true
+  license_key:

--- a/deployment/templates/deployment-pipeline.yaml
+++ b/deployment/templates/deployment-pipeline.yaml
@@ -148,7 +148,7 @@ Resources:
               commands:
                 - echo Build started on `date`
                 - echo Running [./gradlew clean assemble check docker dockerTag dockerPush -PTAG=${TAG} -PREPOSITORY_URI=${REPOSITORY_URI}]
-                - ./gradlew clean assemble check docker dockerTag dockerPush -PTAG=${TAG} -PREPOSITORY_URI=${REPOSITORY_URI}"
+                - ./gradlew clean assemble check docker dockerTag dockerPush -PTAG=${TAG} -PREPOSITORY_URI=${REPOSITORY_URI}
                 - printf '[{"name":"%s","imageUri":"%s"}]' "${CONTAINER_NAME_ARG}" "${REPOSITORY_URI}:${TAG}" > images.json
                 - echo [{"name":"${CONTAINER_NAME_ARG}","imageUri":"${REPOSITORY_URI}:${TAG}"}]
                 - echo Build completed on `date`

--- a/deployment/templates/deployment-pipeline.yaml
+++ b/deployment/templates/deployment-pipeline.yaml
@@ -16,10 +16,6 @@ Metadata:
       - GitHubRepo
       - GitHubBranch
       - GitHubToken
-    - Label:
-        default: Service Parameters
-      Parameters:
-      - SpringProfiles
 
 Parameters:
   ParentECSStack:
@@ -40,17 +36,6 @@ Parameters:
   GitHubToken:
     Type: String
     NoEcho: true
-
-  SpringProfiles:
-    Default: default,production
-    Type: String
-
-  ServiceEnvironment:
-    Type: String
-
-  NewRelicEnabled:
-    Default: false
-    Type: String
 
 Resources:
   CodeBuildServiceRole:
@@ -162,8 +147,8 @@ Resources:
             build:
               commands:
                 - echo Build started on `date`
-                - echo Running [./gradlew clean assemble check docker dockerTag dockerPush -PTAG=${TAG} -PBRANCH=master -PREPOSITORY_URI=${REPOSITORY_URI} -PSPRING_PROFILES="${SPRING_PROFILE_ARG}" -PNEWRELIC_ENABLED="${NEWRELIC_ENABLED_ARG}" -PENVIRONMENT="${ENVIRONMENT_ARG}"]
-                - ./gradlew clean assemble check docker dockerTag dockerPush -PTAG=${TAG} -PBRANCH=master -PREPOSITORY_URI=${REPOSITORY_URI} -PSPRING_PROFILES="${SPRING_PROFILE_ARG}" -PNEWRELIC_ENABLED="${NEWRELIC_ENABLED_ARG}" -PENVIRONMENT="${ENVIRONMENT_ARG}"
+                - echo Running [./gradlew clean assemble check docker dockerTag dockerPush -PTAG=${TAG} -PREPOSITORY_URI=${REPOSITORY_URI}]
+                - ./gradlew clean assemble check docker dockerTag dockerPush -PTAG=${TAG} -PREPOSITORY_URI=${REPOSITORY_URI}"
                 - printf '[{"name":"%s","imageUri":"%s"}]' "${CONTAINER_NAME_ARG}" "${REPOSITORY_URI}:${TAG}" > images.json
                 - echo [{"name":"${CONTAINER_NAME_ARG}","imageUri":"${REPOSITORY_URI}:${TAG}"}]
                 - echo Build completed on `date`
@@ -183,12 +168,6 @@ Resources:
           Value: !Ref AWS::Region
         - Name: REPOSITORY_URI
           Value: !Join ['', ["Fn::Sub": '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/', "Fn::ImportValue": {"Fn::Sub":'${ParentServiceStack}-RepositoryName'}, '']]
-        - Name: SPRING_PROFILE_ARG
-          Value: !Ref SpringProfiles
-        - Name: ENVIRONMENT_ARG
-          Value: !Ref ServiceEnvironment
-        - Name: NEWRELIC_ENABLED_ARG
-          Value: !Ref NewRelicEnabled
         - Name: CONTAINER_NAME_ARG
           Value:
             'Fn::ImportValue': !Sub '${ParentServiceStack}-ContainerName'

--- a/deployment/templates/service.yaml
+++ b/deployment/templates/service.yaml
@@ -19,7 +19,12 @@ Metadata:
       - MemoryLimit
       - MemoryReservation
       - HealthCheckGracePeriodSeconds
+    - Label:
+        default: Application Parameters
+      Parameters:
       - ApplicationContext
+      - JavaOptions
+      - SpringProfile
     - Label:
         default: Logging Parameters
       Parameters:
@@ -50,6 +55,12 @@ Parameters:
     Default: 180
 
   ApplicationContext:
+    Type: String
+
+  JavaOptions:
+    Type: String
+
+  SpringProfile:
     Type: String
 
   MemoryReservation:
@@ -104,11 +115,11 @@ Resources:
     Properties:
       ListenerArn:
         'Fn::ImportValue': !Sub '${ParentECSStack}-ExternalLoadBalancerListener'
-      Priority: 2
+      Priority: 6
       Conditions:
       - Field: path-pattern
         Values:
-        - !Sub "/${ApplicationContext}/*"
+        - !Sub "${ApplicationContext}/*"
       Actions:
       - TargetGroupArn: !Ref ExternalTargetGroup
         Type: forward
@@ -166,6 +177,11 @@ Resources:
             splunk-url: !Ref SplunkUrl
             env: !Ref SplunkEnv
             splunk-insecureskipverify: true
+        Environment:
+          - Name: JAVA_OPTS
+            Value: !Ref JavaOptions
+          - Name: SPRING_PROFILES_ACTIVE
+            Value: !Ref SpringProfile
 
   HTTPCodeTarget5XXTooHighAlarm:
     Condition: HasAlertTopic
@@ -219,8 +235,6 @@ Outputs:
   ApplicationContext:
     Description: 'The application context of the service'
     Value: !Sub "${ApplicationContext}/"
-    Export:
-      Name: !Sub '${AWS::StackName}-ApplicationContext'
   ContainerName:
     Description: 'The container name for the service'
     Value: !Ref ContainerName

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,6 @@ management:
       newrelic:
         enabled: false
 ---
-
 spring:
   profiles: production
 management:


### PR DESCRIPTION
The changes here should simplify the container build, configuration and run time. Instead of configuring the container at build time, all configuration is done via environment variables at runtime.

- Upgraded Gradle to version 4.9
- Updated README.md
- Updated task definition to take environment variables
- Stripped out redundant aspects from Dockerfile and build.gradle