### PR TITLE
Tune memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ docker run -p 8080:8080 -i -t -e JAVA_OPTS="-javaagent:newrelic/newrelic.jar -Dn
 #### Recommended JAVA_OPTS
 It is strongly recommended that the following Java Options are set when running the service in production.
 
-**-XX:MaxRAMFraction=n** should only be set to 1 for containers with only 1 processes running. Setting the value will set the heap to 50% of the memory in the container.
+**-XX:MaxRAMFraction=n** should only be set to 1 for containers with only 1 processes running. Setting the value will set the heap to 100% of the memory in the container.
 ```base
-JAVA_OPTS="-XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -javaagent:newrelic/newrelic.jar -Dnewrelic.environment=${environment} -Dnewrelic.config.file=newrelic/newrelic.yml -Djava.security.egd=file:/dev/./urandom"
+JAVA_OPTS="-XX:MaxRAMFraction=2 -XX:+UseG1GC -XX:+AlwaysPreTouch -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -javaagent:newrelic/newrelic.jar -Dnewrelic.environment=${environment} -Dnewrelic.config.file=newrelic/newrelic.yml -Djava.security.egd=file:/dev/./urandom"
 ```
 
 ## For more tasks run

--- a/deployment/templates/service.yaml
+++ b/deployment/templates/service.yaml
@@ -65,12 +65,12 @@ Parameters:
 
   MemoryReservation:
     Type: Number
-    Default: 512
+    Default: 768
     AllowedValues: [16, 32, 64, 128, 256, 512, 768, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
 
   MemoryLimit:
     Type: Number
-    Default: 512
+    Default: 768
     AllowedValues: [16, 32, 64, 128, 256, 512, 768, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096]
 
   CPUReservation:


### PR DESCRIPTION
Updated default memory settings based on working production configuration.

The settings give 1/3 more memory to the JVM than running the container with 1024MB memory and default memory settings.