### PR TITLE
Refactor error controller to return the actual status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
   include:
   - stage: test
   - stage: deploy to development
+    if: env(DEV_ACCOUNT_ID) is present
     jdk: openjdk8
     env:
     - CLUSTER_NAME=
@@ -44,6 +45,7 @@ jobs:
       on:
         branch: master
   - stage: deploy to production
+    if: env(PROD_ACCOUNT_ID) is present
     jdk: openjdk8
     env:
     - CLUSTER_NAME=

--- a/src/main/java/com/bnc/sbjb/rest/DefaultErrorController.java
+++ b/src/main/java/com/bnc/sbjb/rest/DefaultErrorController.java
@@ -1,9 +1,11 @@
 package com.bnc.sbjb.rest;
 
+import com.bnc.sbjb.model.api.CustomError;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -11,11 +13,10 @@ public class DefaultErrorController implements ErrorController {
 
     private static final String PATH = "/error";
 
-    @ResponseStatus(HttpStatus.NOT_FOUND)
     @RequestMapping(value = PATH)
-    public void error() {
-        // Blank method since we don't need to do anything to handle unknown paths.
-        // Any forked service may choose to handle some requests differently.
+    public ResponseEntity<CustomError> error(HttpServletResponse response) {
+        HttpStatus status = HttpStatus.valueOf(response.getStatus());
+        return ResponseEntity.status(response.getStatus()).body(new CustomError(status, status.getReasonPhrase()));
     }
 
     @Override


### PR DESCRIPTION
1. Error controller can return the status code instead of always returning 404
2. Travis CI should try to deploy only if the environment variables are present so as to prevent the build from failing.