### PR TITLE
Use single ECR for storing images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   # PROD_ACCOUNT_ID,PROD_ACCESS_KEY_ID,PROD_SECRET_ACCESS_KEY
   - AWS_DEFAULT_REGION=
   - ECR_REPOSITORY_NAME=
+  - REPOSITORY_URI=$PROD_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPOSITORY_NAME;
 before_install:
 - pip install --user pip --upgrade
 - pip install --user awscli --upgrade
@@ -24,6 +25,12 @@ cache:
   - "$HOME/.local"
 script:
 - ./gradlew check sonarqube
+after_success:
+- if [ "$TRAVIS_BRANCH" == "master" ]; then
+    AWS_ACCESS_KEY_ID=$PROD_ACCESS_KEY_ID;
+    AWS_SECRET_ACCESS_KEY=$PROD_SECRET_ACCESS_KEY;
+    deployment/scripts/common/push-docker-image.sh;
+  fi
 jobs:
   include:
   - stage: test
@@ -35,11 +42,9 @@ jobs:
     - SERVICE_NAME=
     - AWS_ACCESS_KEY_ID=$DEV_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY=$DEV_SECRET_ACCESS_KEY
-    - REPOSITORY_URI=$DEV_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPOSITORY_NAME
     script: skip
-    before_deploy: deployment/scripts/common/push-docker-image.sh
+    after_success: skip
     deploy:
-      skip_cleanup: true
       provider: script
       script: ecs deploy $CLUSTER_NAME $SERVICE_NAME --tag $TRAVIS_BUILD_NUMBER --no-deregister
       on:
@@ -52,16 +57,14 @@ jobs:
     - SERVICE_NAME=
     - AWS_ACCESS_KEY_ID=$PROD_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY=$PROD_SECRET_ACCESS_KEY
-    - REPOSITORY_URI=$PROD_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPOSITORY_NAME
-    before_deploy: deployment/scripts/common/push-docker-image.sh
+    script: skip
+    after_success: skip
     deploy:
-      skip_cleanup: true
       provider: script
       script: ecs deploy $CLUSTER_NAME $SERVICE_NAME --tag $TRAVIS_BUILD_NUMBER --no-deregister
       on:
         branch: master
   allow_failures:
-  - jdk: openjdk10
   - jdk: openjdk11
   fast_finish: true
 notifications:

--- a/deployment/templates/repository.yaml
+++ b/deployment/templates/repository.yaml
@@ -9,6 +9,9 @@ Parameters:
   DevelopmentAccountId:
     Description: 'The development account id which needs access to the repository'
     Type: String
+  ProductionAccountId:
+    Description: 'The production account id which needs access to the repository'
+    Type: String    
 
 Resources:
   Repository:
@@ -20,11 +23,12 @@ Resources:
         Version: "2012-10-17"
         Statement:
           -
-            Sid: AllowPushPull
+            Sid: AllowDockerImagePull
             Effect: Allow
             Principal:
               AWS:
                 - !Sub 'arn:aws:iam::${DevelopmentAccountId}:root'
+                - !Sub 'arn:aws:iam::${ProductionAccountId}:root'
             Action:
               - "ecr:GetDownloadUrlForLayer"
               - "ecr:BatchGetImage"

--- a/deployment/templates/repository.yaml
+++ b/deployment/templates/repository.yaml
@@ -6,6 +6,9 @@ Parameters:
     Type: String
   ParentServiceStack:
     Type: String
+  DevelopmentAccountId:
+    Description: 'The development account id which needs access to the repository'
+    Type: String
 
 Resources:
   Repository:
@@ -13,6 +16,19 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       RepositoryName: !Ref RepositoryName
+      RepositoryPolicyText:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Sid: AllowPushPull
+            Effect: Allow
+            Principal:
+              AWS:
+                - !Sub 'arn:aws:iam::${DevelopmentAccountId}:root'
+            Action:
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:BatchGetImage"
+              - "ecr:BatchCheckLayerAvailability"
 
 Outputs:
   ServiceName:

--- a/deployment/templates/service.yaml
+++ b/deployment/templates/service.yaml
@@ -23,6 +23,11 @@ Metadata:
       - ExternalFacing
       - LoadBalancerPriority
     - Label:
+        default: Container Registry Parameters
+      Parameters:
+        - RegistryAWSAccountId
+        - RegistryAWSRegion
+    - Label:
         default: Application Parameters
       Parameters:
       - ApplicationContext
@@ -105,6 +110,12 @@ Parameters:
     NoEcho: true
 
   SplunkUrl:
+    Type: String
+
+  RegistryAWSAccountId:
+    Type: String
+
+  RegistryAWSRegion:
     Type: String
 
 Conditions:
@@ -205,6 +216,21 @@ Resources:
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole
 
+  TaskeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument: |
+        {
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": { "Service": [ "ecs-tasks.amazonaws.com" ]},
+                "Action": [ "sts:AssumeRole" ]
+            }]
+        }
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
   ExternalService:
     DependsOn:
       - ExternalTargetGroup
@@ -261,9 +287,10 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: !Sub ${AWS::StackName}-Task
+      TaskRoleArn: !Ref IndexControllerTaskRole
       ContainerDefinitions:
       - Name: !Ref ContainerName
-        Image: !Join ['', ["Fn::Sub": '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/', "Fn::ImportValue": {"Fn::Sub":'${AWS::StackName}-RepositoryName'}, ':latest']]
+        Image: !Join ['', ["Fn::Sub": '${RegistryAWSAccountId}.dkr.ecr.${RegistryAWSRegion}.amazonaws.com/', "Fn::ImportValue": {"Fn::Sub":'${AWS::StackName}-RepositoryName'}, ':latest']]
         Essential: true
         Cpu: !Ref CPUReservation
         Memory: !Ref MemoryLimit


### PR DESCRIPTION
This will speed up our deployments by between 1-5 minutes per build since the image is only pushed once. This also gives each task a default role as well, this will stop them from inheriting service and instance privileges.

Best practice would be to have the repositories in an BNC operational account.