### PR TITLE
Reduce Micrometer logging

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -28,6 +28,7 @@ management:
     export:
       newrelic:
         enabled: false
+        connect-timeout: 10s
     tags:
       application: ${spring.application.name}
       container: ${HOSTNAME:}${COMPUTERNAME:}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
 logging:
   level:
-    io.micrometer.newrelic: WARN
+    io.micrometer.newrelic: ERROR
 
 resource:
   path: /sbjb


### PR DESCRIPTION
Increase the connect timeout for newrelic reporter

This is to remove the intermittent connection errors in the logs
when services try to send metrics to newrelic.