### PR TITLE
Speed up Dockerfile

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -4,9 +4,10 @@ ARG JAR_FILE
 
 RUN  apt-get update && apt-get install -y wget
 
-COPY ${JAR_FILE} app.jar
 RUN mkdir newrelic && wget https://download.newrelic.com/newrelic/java-agent/newrelic-agent/4.12.1/newrelic-agent-4.12.1.jar -O newrelic/newrelic.jar
 COPY newrelic.yml newrelic/newrelic.yml
+
+COPY ${JAR_FILE} app.jar
 
 EXPOSE 8080
 


### PR DESCRIPTION
Move the compiled jar copy line so that it doesn't invalidate dockers cache of New Relics Jar, thus preventing
it from re downloading it.

On my own machine this knocks the time taken to build the docker container on the Taxonomy down from 30 seconds to 5 seconds approximately.