### PR TITLE
Using command line arguments is security-sensitive

### DIFF
--- a/service/src/main/java/com/bnc/sbjb/Application.java
+++ b/service/src/main/java/com/bnc/sbjb/Application.java
@@ -9,7 +9,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Application {
 
     public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
+        SpringApplication.run(Application.class);
     }
 
     @PostConstruct


### PR DESCRIPTION
Unless there is a need to pass in application arguments, this should be avoided.

See: https://rules.sonarsource.com/java/type/Security%20Hotspot/RSPEC-4823